### PR TITLE
Fix broken caroussel register now button

### DIFF
--- a/index.html
+++ b/index.html
@@ -129,7 +129,7 @@
                 Synchronise<br>and <span style="color: var(--main-color)">collaborate.</span>
               </h2>
               <div class="qfc-button">
-                <a href="https://qfield.cloud" target="_blank" title="Register now">
+                <a href="https://app.qfield.cloud/accounts/signup/" target="_blank" title="Register now">
                   <i class="fas fa-cloud"></i> REGISTER NOW</a>
               </div>
             </div>


### PR DESCRIPTION
The QFieldCloud home's ( register now ) button below is broken:

<img width="783" height="571" alt="image" src="https://github.com/user-attachments/assets/738f96fa-dec6-4c33-9cbe-9207e7f96a81" />

This PR fixes it.